### PR TITLE
use lambda::env::function_name()

### DIFF
--- a/rust-aws-lambda/src/main.rs
+++ b/rust-aws-lambda/src/main.rs
@@ -2,8 +2,7 @@ extern crate aws_lambda as lambda;
 
 fn main() {
     lambda::start(|()| {
-        let ctx = lambda::Context::current();
-        println!("hello world, this is {}", ctx.invoked_function_arn());
+        println!("hello world, this is {}", lambda::env::function_name());
         Ok(())
     })
 }


### PR DESCRIPTION
I don't expect much of a perf difference from this particular change, just bringing this example fully on-par with the rest.